### PR TITLE
Blank-out DeviceUniqueId.

### DIFF
--- a/BuildTask/TelemetryPayload.cs
+++ b/BuildTask/TelemetryPayload.cs
@@ -154,6 +154,7 @@ public class TelemetryPayload
 
             if (version is 2)
             {
+                reader.ReadString(); // Skip DeviceUniqueId.
                 result.AccelerateTier = (AccelerateTier)reader.ReadByte();
                 result.OperatingSystem = reader.ReadString();
             }

--- a/BuildTask/TelemetryPayload.cs
+++ b/BuildTask/TelemetryPayload.cs
@@ -63,8 +63,8 @@ public class TelemetryPayload
     public string OSDescription { get; private set; }
     
     public Architecture ProcessorArchitecture { get; private set; }
-    
-    //Additions for V2 
+
+    [Obsolete("Use Machine GUID instead")]
     public string DeviceUniqueId { get; private set; } 
     
     public AccelerateTier AccelerateTier { get; private set; } 
@@ -150,16 +150,15 @@ public class TelemetryPayload
             result.AvaloniaMainPackageVersion = reader.ReadString();
             result.OSDescription = reader.ReadString();
             result.ProcessorArchitecture = (Architecture)reader.ReadByte();
+            result.DeviceUniqueId = "";
 
             if (version is 2)
             {
-                result.DeviceUniqueId = reader.ReadString();
                 result.AccelerateTier = (AccelerateTier)reader.ReadByte();
                 result.OperatingSystem = reader.ReadString();
             }
             else if (version is 1)
             {
-                result.DeviceUniqueId = "";
                 result.OperatingSystem = "Unknown";
             }
         }
@@ -219,7 +218,7 @@ public class TelemetryPayload
         result.ProjectHash = HashProperty(projectName);
 
         // New for V2
-        result.DeviceUniqueId = HashProperty($"{Environment.MachineName}-{Environment.UserName}-{Environment.OSVersion.Platform}");
+        result.DeviceUniqueId = "";
         result.AccelerateTier = accelerateTier;
         result.OperatingSystem = GetOperatingSystem();
         return result;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Minimal, anonymised information (hashed with SHA256 where applicable):
 * Output type, target framework, runtime identifier
 * Avalonia version in use
 * Accelerate license tier (indie, business, enterprise...)
-* Anonymous machine identifier (GUID), and machine name (hashed)
+* Anonymous machine identifier (GUID)
 * Development environment (Visual Studio, Rider, VS Code, CLI)
 * Operating system version and architecture
 * CI environment detection (Azure DevOps, GitHub Actions, etc.)


### PR DESCRIPTION
It's possible that `DeviceUniqueId` could be considered PII by the GDPR (though open to interpretation) - remove it to be on the safe side.

Fixes #4.