### PR TITLE
Generate a CycloneDX SBOM for the shipped NuGet package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
+        submodules: true
 
     - name: Install .NET
       uses: actions/setup-dotnet@v5
@@ -29,3 +30,10 @@ jobs:
       with:
         name: Nuget package
         path: ./artifacts/packages/*.nupkg
+
+    # Standalone copy of the per-package SBOM that CreateSbom also embeds into the .nupkg.
+    - name: Upload SBOM artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: sbom
+        path: ./artifacts/sbom/*.cdx.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-common"]
+	path = build-common
+	url = https://github.com/AvaloniaUI/build-common

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -26,6 +26,7 @@
       "enum": [
         "CleanArtifacts",
         "CreatePackage",
+        "CreateSbom",
         "MergeLicensing",
         "OutputParameters",
         "RunBuild"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -124,7 +124,20 @@ class Build : NukeBuild
         var purl = $"pkg:nuget/AvaloniaUI.Licensing@{licensingVersion}";
 
         var doc = JsonNode.Parse(File.ReadAllText(sbomPath))!.AsObject();
-        doc["components"]!.AsArray().Add(new JsonObject
+        var components = doc["components"]!.AsArray();
+
+        // If the shared generator ever starts emitting the component itself (e.g. the reference
+        // moves off PrivateAssets="All" and licensing lands back in the shipped nuspec, where the
+        // generator's cross-check re-adds it), this manual step is obsolete - skip it rather than
+        // emit a duplicate bom-ref.
+        if (components.Any(c => c?["name"]?.GetValue<string>() == "AvaloniaUI.Licensing"))
+        {
+            Log.Warning("SBOM: AvaloniaUI.Licensing is already present in the generated SBOM - " +
+                        "the manual AddMergedLicensingComponent step is obsolete and can be removed.");
+            return;
+        }
+
+        components.Add(new JsonObject
         {
             ["type"] = "library",
             ["bom-ref"] = purl,

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,9 +1,14 @@
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
+using NukeExtensions;
 using Serilog;
 
 class Build : NukeBuild
@@ -15,6 +20,7 @@ class Build : NukeBuild
     readonly AbsolutePath Output = RootDirectory / "artifacts" / "packages";
 
     [NuGetPackage("dotnet-ilrepack", "ILRepackTool.dll", Framework = "net8.0")] readonly Tool IlRepackTool;
+    [NuGetPackage("CycloneDX", "CycloneDX.dll", Framework = "net9.0")] readonly Tool CycloneDx;
 
     AbsolutePath BuildServicesProject => RootDirectory / "BuildTask" / "Avalonia.BuildServices.csproj";
 
@@ -74,6 +80,78 @@ class Build : NukeBuild
             var pkg= Output.GlobFiles("*.nupkg").Single();
             RefAssemblyGenerator.GenerateRefAsmsInPackage(pkg);
         });
+
+    // Generates a CycloneDX SBOM (EU Cyber Resilience Act evidence) for the shipped package and
+    // embeds it into the .nupkg at _manifest/cyclonedx/bom.cdx.json. TriggeredBy makes the default
+    // CreatePackage target produce it with no build-command changes; it must run after
+    // RefAssemblyGenerator so the recorded hashes are those of the binaries actually shipped.
+    Target CreateSbom => _ => _
+        .DependsOn(CreatePackage)
+        .TriggeredBy(CreatePackage)
+        .Executes(() =>
+        {
+            var pkg = Output.GlobFiles("*.nupkg").Single();
+            var sbomOutput = RootDirectory / "artifacts" / "sbom";
+            sbomOutput.CreateOrCleanDirectory();
+
+            // The Collector's output is bundled into the package's tools/ folder, so it's a
+            // constituent of the shipped package and its dependencies belong in the SBOM.
+            SbomGenerator.GenerateForPackage(
+                CycloneDx,
+                RootDirectory,
+                pkg,
+                sbomOutput,
+                GetVersion(),
+                "Avalonia.BuildServices",
+                new[] { "Avalonia.BuildServices", "Avalonia.BuildServices.Collector" },
+                projectSearchDirs: new[] { "BuildTask", "Avalonia.BuildServices.Collector" });
+
+            AddMergedLicensingComponent(sbomOutput / $"Avalonia.BuildServices.{GetVersion()}.cdx.json", pkg);
+        });
+
+    // AvaloniaUI.Licensing is IL-merged into Avalonia.BuildServices.dll (MergeLicensing) and
+    // referenced with PrivateAssets="All", so the shared generator can't see it: cyclonedx-dotnet
+    // excludes it as a dev dependency, it's absent from the shipped nuspec (which would otherwise
+    // re-add it), and the merged bytes live inside the package's primary assembly, which the
+    // package-content scan deliberately skips. Its code ships regardless, so record it explicitly,
+    // in both the standalone SBOM and the copy embedded in the package.
+    void AddMergedLicensingComponent(AbsolutePath sbomPath, AbsolutePath nupkgPath)
+    {
+        var licensingVersion = XDocument.Load(BuildServicesProject).Descendants()
+            .First(x => x.Name.LocalName == "PackageReference" &&
+                        x.Attribute("Include")?.Value == "AvaloniaUI.Licensing")
+            .Attribute("Version")!.Value;
+        var purl = $"pkg:nuget/AvaloniaUI.Licensing@{licensingVersion}";
+
+        var doc = JsonNode.Parse(File.ReadAllText(sbomPath))!.AsObject();
+        doc["components"]!.AsArray().Add(new JsonObject
+        {
+            ["type"] = "library",
+            ["bom-ref"] = purl,
+            ["name"] = "AvaloniaUI.Licensing",
+            ["version"] = licensingVersion,
+            ["purl"] = purl,
+            ["scope"] = "required"
+        });
+
+        var rootRef = doc["metadata"]!["component"]!["bom-ref"]!.GetValue<string>();
+        var rootNode = doc["dependencies"]!.AsArray().OfType<JsonObject>()
+            .First(d => d["ref"]!.GetValue<string>() == rootRef);
+        rootNode["dependsOn"]!.AsArray().Add(purl);
+
+        var sbomJson = doc.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(sbomPath, sbomJson);
+
+        // Replace the copy GenerateForPackage embedded so the two stay identical. The package is
+        // not signed at this point (nuget.org signs server-side on push), and "json" is already
+        // registered in [Content_Types].xml by the original embed.
+        using var zip = ZipFile.Open(nupkgPath, ZipArchiveMode.Update);
+        const string entryPath = "_manifest/cyclonedx/bom.cdx.json";
+        zip.GetEntry(entryPath)!.Delete();
+        using var entryStream = zip.CreateEntry(entryPath).Open();
+        using var writer = new StreamWriter(entryStream);
+        writer.Write(sbomJson);
+    }
 
     string GetVersion()
     {

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -15,6 +15,8 @@
         <PackageReference Include="Nuke.Common" Version="9.0.4"/>
         <PackageReference Include="Mono.Cecil" Version="0.11.6"/>
     	<PackageDownload Include="dotnet-ilrepack" Version="[2.0.44]"/>
+        <PackageDownload Include="CycloneDX" Version="[6.2.0]"/>
+        <ProjectReference Include="..\build-common\nuke\NukeExtensions.csproj"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Adds a `CreateSbom` nuke target that produces a **CycloneDX SBOM** for the shipped `Avalonia.BuildServices` package, as EU Cyber Resilience Act technical-documentation evidence. Uses the shared generator merged in AvaloniaUI/build-common#4; see AvaloniaUI/Avalonia.Controls.TreeDataGrid-Accelerate#169 for the pilot.

- `CreateSbom` is `.TriggeredBy(CreatePackage)`, so the existing default target generates and embeds the SBOM with no build-command changes. It runs after `RefAssemblyGenerator`, so the recorded SHA-512 hashes are those of the binaries actually shipped. The standalone copy lands in `artifacts/sbom/` and CI uploads it as an `sbom` workflow artifact; an identical copy is embedded into the `.nupkg` at `_manifest/cyclonedx/bom.cdx.json`.
- Both constituent projects are scanned: `Avalonia.BuildServices` and `Avalonia.BuildServices.Collector`, whose output is bundled into the package''s `tools/` folder.
- **Submodule pin**: the new `build-common` submodule points at the head of AvaloniaUI/build-common#5 (`2272ff9`) rather than main, because this repository keeps its package project under `BuildTask/` and needs that PR''s `projectSearchDirs` parameter (same pin as the Xpf companion PR). Bump to the merge commit once #5 lands.
- **AvaloniaUI.Licensing**: IL-merged into the shipped assembly and referenced with `PrivateAssets="All"`, so all three of the shared generator''s detection paths miss it — cyclonedx-dotnet excludes it as a dev dependency, it''s absent from the shipped nuspec (the cross-check that rescues it in the other component repos, which use partial `PrivateAssets`), and the merged bytes live inside the primary assembly the package-content scan deliberately skips. Its code ships regardless, so `Build.cs` adds it to the SBOM explicitly, reading the version from the csproj''s `PackageReference` so it can''t drift, and rewrites both the standalone file and the embedded copy.
- The two shipped binaries appear in the SBOM under names like `Avalonia.BuildServices.<guid>@0.0.0.0` — accurate, since `RefAssemblyGenerator` deliberately randomizes the shipped assemblies'' identities per build; each component carries an `avalonia:packagePath` property identifying the real file, plus a SHA-512 of the shipped bytes.

## Test plan

- [x] Ran the full nuke build locally: both constituent projects located and scanned, SBOM generated with correct root metadata (MIT licence, supplier, repository URL), 21 resolved NuGet dependencies, both shipped DLLs recorded with SHA-512 hashes in a complete composition, and `AvaloniaUI.Licensing@3.0.0-rc2` present with a dependency edge from the root
- [x] Verified the embedded `_manifest/cyclonedx/bom.cdx.json` is byte-identical to the standalone copy and `json` is registered in `[Content_Types].xml`
- [x] Verified the CycloneDX tool runs on the same .NET 9 runtime as the rest of the build (no extra SDK needed in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)